### PR TITLE
explicit Dist::Zilla author dependencies

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,6 +7,7 @@ copyright_year   = 2014-2025
 [VersionFromModule]
 [MinimumPerl]
 [AutoPrereqs]
+[Prereqs::AuthorDeps]
 
 [CheckChangesHasContent]
 [NextRelease]
@@ -17,6 +18,7 @@ authority = cpan:GENE
 [PkgVersion]
 [PodWeaver]
 
+; authordep Pod::Coverage::TrustPod
 [PodCoverageTests]
 [PodSyntaxTests]
 [Test::NoTabs]


### PR DESCRIPTION
-   add [Pod::Coverage::TrustPod](https://metacpan.org/dist/Pod-Coverage-TrustPod) to dist.ini author dependencies so that `dzil authordeps --missing` catches it, even though it’s already automatically added to the CPAN metadata develop prereqs by the [PodCoverageTests plugin](https://metacpan.org/pod/Dist::Zilla::Plugin::PodCoverageTests)
-   add [Prereqs::AuthorDeps Dist::Zilla plugin](https://metacpan.org/dist/Dist-Zilla-Plugin-Prereqs-AuthorDeps) to make sure all [Dist::Zilla author dependencies](https://metacpan.org/pod/Dist::Zilla::App::Command::authordeps) are captured in [CPAN metadata develop prereqs](https://metacpan.org/pod/CPAN::Meta::Spec#develop)