### PR TITLE
make add_fill warn to STDERR instead of printing

### DIFF
--- a/lib/MIDI/Drummer/Tiny.pm
+++ b/lib/MIDI/Drummer/Tiny.pm
@@ -1009,7 +1009,7 @@ sub add_fill {
         };
     };
     my $fill_patterns = $fill->($self);
-    print 'Fill: ', ddc($fill_patterns) if $self->verbose;
+    warn 'Fill: ', ddc($fill_patterns) if $self->verbose;
     my $fill_duration = delete $fill_patterns->{duration} || 8;
     my $fill_length   = length((values %$fill_patterns)[0]);
 
@@ -1019,17 +1019,17 @@ sub add_fill {
     }
 
     my $lcm = _multilcm($fill_duration, values %lengths);
-    print "LCM: $lcm\n" if $self->verbose;
+    warn "LCM: $lcm\n" if $self->verbose;
 
     my $size = 4 / $lcm;
     my $dump = reverse_dump('length');
     my $master_duration = $dump->{$size} || $self->eighth; # XXX this || is not right
-    print "Size: $size, Duration: $master_duration\n" if $self->verbose;
+    warn "Size: $size, Duration: $master_duration\n" if $self->verbose;
 
     my $fill_chop = $fill_duration == $lcm
         ? $fill_length
         : int($lcm / $fill_length) + 1;
-    print "Chop: $fill_chop\n" if $self->verbose;
+    warn "Chop: $fill_chop\n" if $self->verbose;
 
     my %fresh_patterns;
     for my $instrument (keys %patterns) {
@@ -1040,7 +1040,7 @@ sub add_fill {
             ? [ join '', @{ upsize($pattern, $lcm) } ]
             : [ join '', @$pattern ];
     }
-    print 'Patterns: ', ddc(\%fresh_patterns) if $self->verbose;
+    warn 'Patterns: ', ddc(\%fresh_patterns) if $self->verbose;
 
     my %replacement;
     for my $instrument (keys %$fill_patterns) {
@@ -1053,7 +1053,7 @@ sub add_fill {
         # the replacement string is the tail of the fresh pattern string
         $replacement{$instrument} = substr $fresh, -$fill_chop;
     }
-    print 'Replacements: ', ddc(\%replacement) if $self->verbose;
+    warn 'Replacements: ', ddc(\%replacement) if $self->verbose;
 
     my %replaced;
     for my $instrument (keys %fresh_patterns) {
@@ -1062,7 +1062,7 @@ sub add_fill {
         # replace the tail of the string
         my $pos = length $replacement{$instrument};
         substr $string, -$pos, $pos, $replacement{$instrument};
-        print "$instrument: $string\n" if $self->verbose;
+        warn "$instrument: $string\n" if $self->verbose;
         # prepare the replaced pattern for syncing
         $replaced{$instrument} = [ $string ];
     }

--- a/t/verbose_add_fill.t
+++ b/t/verbose_add_fill.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use English qw(-no_match_vars);
+use Test2::V0;
+use Test::Output 0.04;
+plan 3;
+
+use MIDI::Drummer::Tiny;
+
+can_ok 'MIDI::Drummer::Tiny', [qw(add_fill)], 'has necessary methods';
+
+# direct any MIDI output to a throwaway scalar reference filehandle
+my $midi;
+open my $midi_fh, '>', \$midi
+    or bail_out "can't open MIDI output to a variable: $OS_ERROR";
+my $drummer
+    = MIDI::Drummer::Tiny->new( verbose => 1, file => $midi_fh );
+isa_ok $drummer, [qw(MIDI::Drummer::Tiny)], 'constructed object';
+
+# test multi-line verbose STDOUT/STDERR of default add_fill
+output_like( sub { $drummer->add_fill },
+    qr//m, qr/.+/m, 'add_fill has STDERR but no STDOUT' );
+close $midi_fh
+    or bail_out "couldn't close MIDI output variable: $OS_ERROR";


### PR DESCRIPTION
This helps keep the MIDI stream clean when piping it via STDOUT to another process like [`timidity`](https://timidity.sourceforge.net).