### PR TITLE
more PodCoverageTests dzil author dependencies

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -18,6 +18,8 @@ authority = cpan:GENE
 [PkgVersion]
 [PodWeaver]
 
+; authordep Test::Pod
+; authordep Test::Pod::Coverage
 ; authordep Pod::Coverage::TrustPod
 [PodCoverageTests]
 [PodSyntaxTests]


### PR DESCRIPTION
Ugh, I noticed on a fresh install that [Test::Pod](https://metacpan.org/dist/Test-Pod) and [Test::Pod::Coverage](https://metacpan.org/dist/Test-Pod-Coverage) were also missing and preventing author tests from succeeding.