### PR TITLE
added note and duration type constraints

### DIFF
--- a/lib/MIDI/Drummer/Tiny.pm
+++ b/lib/MIDI/Drummer/Tiny.pm
@@ -380,7 +380,7 @@ for my $basic_duration ( keys %basic_note_durations ) {
     );
 
     for my $prefix ( keys %duration_prefixes ) {
-        has "${prefix}_${duration}" => (
+        has "${prefix}_${basic_duration}" => (
             is      => 'ro',
             isa     => Duration,
             default => "$duration_prefixes{$prefix}${duration}n",

--- a/lib/MIDI/Drummer/Tiny/Types.pm
+++ b/lib/MIDI/Drummer/Tiny/Types.pm
@@ -1,0 +1,73 @@
+package MIDI::Drummer::Tiny::Types;
+
+# ABSTRACT: Type library for MIDI::Drummer::Tiny
+
+use strict;
+use warnings;
+
+use Type::Library -base, -declare => qw(
+    MIDINote
+    Duration
+    PercussionNote
+);
+use Type::Utils -all;
+
+use Types::Common::Numeric qw(IntRange);
+use Types::Common::String  qw(NonEmptyStr);
+
+use MIDI::Util qw(midi_dump);
+
+=type Duration
+
+A L<non-empty string|Types::Common::String/Types> corresponding to a
+L<duration in MIDI::Simple|MIDI::Simple/"Parameters for n/r/noop">.
+
+=cut
+
+my %length = %{ midi_dump('length') };
+declare Duration, as NonEmptyStr, where { exists $length{$_} };
+
+## no critic (ValuesAndExpressions::ProhibitMagicNumbers)
+
+=type MIDINote
+
+An L<integer from|Types::Common::Numeric/Types> 0 to 127 corresponding
+to a L<MIDI Note Number|/"SEE ALSO">.
+
+=cut
+
+declare MIDINote, as IntRange [ 0, 127 ];
+
+=type PercussionNote
+
+A L</MIDINote> from 27 through 87, corresponding to a value in the
+L<General MIDI 2 Percussion Sound Set|/"SEE ALSO">.
+
+=cut
+
+# TODO: update MIDI-Perl's %MIDI::notenum2percussion with all GM2 sounds
+declare PercussionNote, as MIDINote, where { $_ >= 27 or $_ <= 87 };
+
+=head1 SEE ALSO
+
+=over
+
+=item *
+
+B<Channel Voice Messages: Note Number>
+in I<MIDI 1.0 Detailed Specification (Document Version 4.2.1)>,
+revised February 1996 by the MIDI Manufacturers Association:
+L<https://midi.org/midi-1-0-core-specifications>
+
+=item *
+
+B<Appendix B: GM 2 Percussion Sound Set> in
+I<General MIDI 2 (Version 1.2a)>,
+published February 6, 2007 by the MIDI Manufacturers Association:
+L<https://midi.org/general-midi-2>
+
+=back
+
+=cut
+
+1;

--- a/weaver.ini
+++ b/weaver.ini
@@ -1,0 +1,31 @@
+[@CorePrep]
+
+[-SingleEncoding]
+
+[Name]
+[Version]
+
+[Region  / prelude]
+
+[Generic / SYNOPSIS]
+[Generic / DESCRIPTION]
+[Generic / OVERVIEW]
+
+[Collect / TYPES]
+command = type
+
+[Collect / ATTRIBUTES]
+command = attr
+
+[Collect / METHODS]
+command = method
+
+[Collect / FUNCTIONS]
+command = func
+
+[Leftovers]
+
+[Region  / postlude]
+
+[Authors]
+[Legal]


### PR DESCRIPTION
- Used [Type-Tiny](https://metacpan.org/dist/Type-Tiny) to create a type constraint library for General MIDI 2 percussion notes and the durations available via [MIDI::Util](https://metacpan.org/pod/MIDI::Util). _(Can't use MIDI::Util for notes as it doesn’t include "click" or "bell”)_
- Refactored most attribute definitions to have less repeated code.
- Added [Pod::Weaver](https://metacpan.org/dist/Pod-Weaver) configuration file to enable separate "TYPES" section for the new MIDI::Drummer::Tiny::Types library.