### PR TITLE
*BIG* PR with better use of Type::Tiny, PodWeaver, Moo, Perl v5.20 features

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,6 +17,8 @@ format = %v %{yyyy-MM-dd HH:mm:ss}d
 authority = cpan:GENE
 [PkgVersion]
 [PodWeaver]
+replacer           = replace_with_comment
+post_code_replacer = replace_with_nothing
 
 ; authordep Test::Pod
 ; authordep Test::Pod::Coverage

--- a/lib/MIDI/Drummer/Tiny/Types.pm
+++ b/lib/MIDI/Drummer/Tiny/Types.pm
@@ -5,15 +5,17 @@ package MIDI::Drummer::Tiny::Types;
 use strict;
 use warnings;
 
-use Type::Library -base, -declare => qw(
+use Type::Library -extends => [ qw(
+    Types::Standard
+    Types::Common::Numeric
+    Types::Common::String
+) ],
+    -declare => qw(
     MIDINote
     Duration
     PercussionNote
-);
+    );
 use Type::Utils -all;
-
-use Types::Common::Numeric qw(IntRange);
-use Types::Common::String  qw(NonEmptyStr);
 
 use MIDI::Util qw(midi_dump);
 


### PR DESCRIPTION
Bear with me and please raise questions or concerns. This isn’t take-it-or-leave-it; the PR can be adjusted, reduced, or even split into multiple change sets.

- Ran `perltidy` over the files in `/lib` with [what I hope is a sensible set of options](https://github.com/user-attachments/files/19410748/perltidyrc.txt); I’m happy to talk about that separately if you like, especially how to automate it.
- Type library extended with standard & common types so we don't have to pull them in piecemeal either in the library itself or its consumers.
- Rewrote many methods and functions to use Perl subroutine signatures and defaults, which were introduced experimentally in v5.20 and finally accepted in v5.36.
- Hoisted the `channel`, `volume`, and `bpm` attributes out of the earlier refactor so that they could use the extended type library and their setters/writers could still have side-effects on the MIDI score.

  _(Not 100% sure if these should be consistently either triggers, like with `bpm`, or private writers as with `channel` and `volume`.)_
- Turned the `sync` method into a proxy method on the `score` attribute using Moo’s `handles` feature.
- Adjusted the POD documentation to have more consistent formatting and use Pod::Weaver `=attr` and `=method` gatherer directives.
- Replaced calls to `warn` and `die` with `carp` and `croak`, respectively, to make the error messages more informative about the callers they are coming from.
- Introduced postfix dereferencing syntax (experimental in Perl v5.20, stable in v5.24) for readability.
- Added `dist.ini` directives that will keep the POD documentation as commented lines in the produced code, so that errors with line numbers will be the same across the source code and the woven code in the distribution.