### PR TITLE
require Perl v5.24; use experimental after implicit use warnings

### DIFF
--- a/lib/MIDI/Drummer/Tiny.pm
+++ b/lib/MIDI/Drummer/Tiny.pm
@@ -2,12 +2,12 @@ package MIDI::Drummer::Tiny;
 
 # ABSTRACT: Glorified metronome
 
-use 5.020;
-use experimental qw(postderef signatures);
+use 5.024;
 use strictures 2;
 use Carp;
 use List::Util 1.26 qw(sum0);
 use Moo;
+use experimental qw(signatures);
 use Math::Bezier ();
 use MIDI::Util   qw(
     dura_size


### PR DESCRIPTION
- Upstream CPAN dependency [Music-RhythmSet](https://metacpan.org/pod/Music::RhythmSet::Util) requires Perl v5.24, so this module might as well do the same. Therefore, it no longer needs to flag postfix dereference syntax as experimental.
- `use Moo` [implicitly turns on warnings](https://metacpan.org/pod/Moo#API-INCOMPATIBILITIES), so move `use experimental` after it so that compile tests don't fail because they emitted warnings.