### PR TITLE
catch more errors with (reorganized) type constraints

### DIFF
--- a/lib/MIDI/Drummer/Tiny/Types.pm
+++ b/lib/MIDI/Drummer/Tiny/Types.pm
@@ -5,72 +5,35 @@ package MIDI::Drummer::Tiny::Types;
 use strict;
 use warnings;
 
-use Type::Library
-    -extends => [ qw(
-        Types::Standard
-        Types::Common::Numeric
-        Types::Common::String
-    ) ],
+use Type::Library -extends => [ qw(
+    Types::MIDI
+    Types::Common::String
+) ],
     -declare => qw(
-        MIDINote
-        Duration
-        PercussionNote
+    BPM
+    Duration
     );
 use Type::Utils -all;
 
 use MIDI::Util qw(midi_dump);
 
+=type BPM
+
+A L<positive number|Types::Common::Numeric/PositiveNum> expressing
+beats per minute.
+
+=cut
+
+declare BPM, as PositiveNum;
+
 =type Duration
 
-A L<non-empty string|Types::Common::String/Types> corresponding to a
-L<duration in MIDI::Simple|MIDI::Simple/"Parameters for n/r/noop">.
+A L<non-empty string|Types::Common::String/Types> corresponding to
+a L<duration in MIDI::Simple|MIDI::Simple/"Parameters for n/r/noop">.
 
 =cut
 
 my %length = %{ midi_dump('length') };
 declare Duration, as NonEmptyStr, where { exists $length{$_} };
-
-## no critic (ValuesAndExpressions::ProhibitMagicNumbers)
-
-=type MIDINote
-
-An L<integer from|Types::Common::Numeric/Types> 0 to 127 corresponding
-to a L<MIDI Note Number|/"SEE ALSO">.
-
-=cut
-
-declare MIDINote, as IntRange [ 0, 127 ];
-
-=type PercussionNote
-
-A L</MIDINote> from 27 through 87, corresponding to a value in the
-L<General MIDI 2 Percussion Sound Set|/"SEE ALSO">.
-
-=cut
-
-# TODO: update MIDI-Perl's %MIDI::notenum2percussion with all GM2 sounds
-declare PercussionNote, as MIDINote, where { $_ >= 27 or $_ <= 87 };
-
-=head1 SEE ALSO
-
-=over
-
-=item *
-
-B<Channel Voice Messages: Note Number>
-in I<MIDI 1.0 Detailed Specification (Document Version 4.2.1)>,
-revised February 1996 by the MIDI Manufacturers Association:
-L<https://midi.org/midi-1-0-core-specifications>
-
-=item *
-
-B<Appendix B: GM 2 Percussion Sound Set> in
-I<General MIDI 2 (Version 1.2a)>,
-published February 6, 2007 by the MIDI Manufacturers Association:
-L<https://midi.org/general-midi-2>
-
-=back
-
-=cut
 
 1;

--- a/lib/Types/MIDI.pm
+++ b/lib/Types/MIDI.pm
@@ -1,0 +1,83 @@
+package Types::MIDI;
+
+# ABSTRACT: Type library for MIDI
+
+use strict;
+use warnings;
+
+use Type::Library
+    -extends => [ qw(
+        Types::Common::Numeric
+    ) ],
+    -declare => qw(
+        Channel
+        Velocity
+        Note
+        PercussionNote
+    );
+use Type::Utils -all;
+
+## no critic (ValuesAndExpressions::ProhibitMagicNumbers)
+
+=type Channel
+
+An L<integer from|Types::Common::Numeric/Types> 0 to 15 corresponding
+to a L<MIDI Channel|/"SEE ALSO">.
+
+=cut
+
+declare Channel, as IntRange [ 0, 15 ];
+
+=type Velocity
+
+An L<integer from|Types::Common::Numeric/Types> 0 to 127 corresponding
+to a L<MIDI Velocity|/"SEE ALSO">.
+
+=cut
+
+declare Velocity, as IntRange [ 0, 127 ];
+
+=type Note
+
+An L<integer from|Types::Common::Numeric/Types> 0 to 127 corresponding
+to a L<MIDI Note Number|/"SEE ALSO">.
+
+=cut
+
+declare Note, as IntRange [ 0, 127 ];
+
+=type PercussionNote
+
+A L</Note> from 27 through 87, corresponding to a value in the
+L<General MIDI 2 Percussion Sound Set|/"SEE ALSO">.
+
+=cut
+
+# TODO: update MIDI-Perl's %MIDI::notenum2percussion with all GM2 sounds
+declare PercussionNote, as Note, where { $_ >= 27 or $_ <= 87 };
+
+=head1 SEE ALSO
+
+=over
+
+=item *
+
+I<MIDI 1.0 Detailed Specification (Document Version 4.2.1)>,
+revised February 1996 by the MIDI Manufacturers Association:
+L<https://midi.org/midi-1-0-core-specifications>
+
+=item *
+
+B<Appendix B: GM 2 Percussion Sound Set> in
+I<General MIDI 2 (Version 1.2a)>,
+published February 6, 2007 by the MIDI Manufacturers Association:
+L<https://midi.org/general-midi-2>
+
+=back
+
+=cut
+
+1;
+
+
+1;

--- a/t/01-methods.t
+++ b/t/01-methods.t
@@ -2,6 +2,7 @@
 
 use Data::Dumper::Compact qw(ddc);
 use Test::More;
+use File::Temp qw(tempfile);
 
 use_ok 'MIDI::Drummer::Tiny';
 
@@ -153,16 +154,17 @@ subtest fill => sub {
 };
 
 subtest timidity_conf => sub {
-    my $d = new_ok 'MIDI::Drummer::Tiny' => [
-        soundfont => 'soundfont.sf2',
-    ];
+    my ( $sf_fh, $soundfont )
+        = tempfile( 'soundfontXXXX', SUFFIX => '.sf2', UNLINK => 1 );
+    my ( $timidity_fh, $timidity_conf )
+        = tempfile( 'timidityXXXX', SUFFIX => '.conf', UNLINK => 1 );
+    my $d
+        = new_ok 'MIDI::Drummer::Tiny' => [ soundfont => $soundfont ];
+
     my $sf = $d->soundfont;
-    like $d->timidity_cfg, qr/$sf$/, 'timidity_conf';
-    my $filename = 'timidity_conf';
-    $d->timidity_cfg($filename);
-    ok -e $filename, 'timidity_conf with filename';
-    unlink $filename;
-    ok !-e $filename, 'file unlinked';
+    like $d->timidity_cfg, qr/$sf$/, 'timidity configuration';
+    $d->timidity_cfg($timidity_conf);
+    ok -e $timidity_conf, 'timidity configuration with filename';
 };
 
 done_testing();

--- a/weaver.ini
+++ b/weaver.ini
@@ -27,7 +27,7 @@ command = func
 main_module_only = 1
 text = Any of these attributes may be changed when calling L</new>.
 text = Drumkit values must be a valid
-text = L<MIDI::Drummer::Tiny/PercussionNote>,
+text = L<Types::MIDI/PercussionNote>,
 text = while note duration values must be a valid
 text = L<MIDI::Drummer::Tiny/Duration>.
 


### PR DESCRIPTION
- adjusted names and moved generic (and General) MIDI type constraints to new Types::MIDI library, including new Channel and Velocity types (might spin this off to its own distribution as it matures)
- added a BPM type to this distribution's type library, as it's only applicable to this distribution (and perhaps other [MIDI::Simple](https://metacpan.org/pod/MIDI::Simple) consumers), but not really a [MIDI spec](https://midi.org/midi-1-0-core-specifications) thing
- add [Types::Path::Tiny](https://metacpan.org/pod/Types::Path::Tiny) type constraints to `file` and `soundfont` attributes, still supporting [MIDI::Simple-compatible filehandles](https://metacpan.org/pod/MIDI::Simple#$opus-=-$obj-%3Ewrite_score(filespec)) for the former so that code like `eg/metal.pl` still works
- fixed method tests script to handle required existence of SoundFont files by generating temporary files with [File::Temp](https://perldoc.perl.org/File::Temp)

On a personal note, thank you so much for accepting my input on this distribution. I've really enjoyed getting back into the swing of Perl library development and you've humored my efforts to discover the “right way" to write and maintain a solid module.
